### PR TITLE
Fix linker ssl error fix (libcrypto-1_1-x64.dll not found)

### DIFF
--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
        matrix:
-         os: [windows-latest, ubuntu-latest, macOS-latest]
+         os: [windows-latest]
        fail-fast: false    
     steps:
       - name: (Windows) Install dependencies

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
        matrix:
-         os: [windows-latest, ubuntu-latest, macOS-latest]
+         os: [windows-latest]
        fail-fast: false
     steps:
       - name: (Windows) Install dependencies

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -1,17 +1,17 @@
 name: Build and deploy Aseprite
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
   push:
     branches:
       - master
-  workflow_dispatch:
+      - fix
 
 env:
   BUILD_TYPE: Release
-  ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-  
+
 jobs:
   check-version:
     name: Check latest Aseprite release
@@ -29,21 +29,23 @@ jobs:
         LATEST_TAG=$(echo "${data}" | jq -r '.tag_name')
         DOWNLOAD_URL=$(echo "${data}" | jq -r '.assets[].browser_download_url')
         VERSION_INFO=$(echo "${data}" | jq -r '.body')
-        
+
         echo "${LATEST_TAG}" > ${LATEST_TAG}.txt
-        echo "::set-output name=latest_tag::${LATEST_TAG}"
-        echo "::set-output name=download_url::${DOWNLOAD_URL}"
-        echo "::set-output name=version_info::${VERSION_INFO}"
+        echo "latest_tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
+        echo "download_url=${DOWNLOAD_URL}" >> $GITHUB_OUTPUT
+        echo "version_info<<EOF" >> $GITHUB_OUTPUT
+        echo "$VERSION_INFO" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
     - name: Load version from cache
       id: version_check
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: ${{ steps.version_info.outputs.latest_tag }}.txt
         key: cached_version
     - name: Should we start new build?
       id: should_build
-      if: steps.version_check.outputs.cache-hit != 'true'
-      run: echo "::set-output name=should_build::true"
+      if: github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/fix' || steps.version_check.outputs.cache-hit != 'true'
+      run: echo "should_build=true" >> $GITHUB_OUTPUT
     - name: Create Release
       id: create_release
       if: steps.should_build.outputs.should_build
@@ -57,7 +59,7 @@ jobs:
           ${{ steps.version_info.outputs.version_info }}
         draft: true
         prerelease: false
-  
+
   build-aseprite:
     name: Build Aseprite
     needs: check-version
@@ -65,28 +67,33 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
        matrix:
-         os: [windows-latest]
-       fail-fast: false    
+         os: [windows-latest, ubuntu-latest, macOS-latest]
+       fail-fast: false
     steps:
       - name: (Windows) Install dependencies
         if: matrix.os == 'windows-latest'
-        uses: seanmiddleditch/gha-setup-ninja@v1
+        uses: seanmiddleditch/gha-setup-ninja@v3
       - name: (Ubuntu) Install dependencies
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt install -y cmake ninja-build libxcursor-dev libxi-dev libgl1-mesa-dev
+        run: sudo apt update && sudo apt install -y cmake ninja-build libxcursor-dev libxi-dev libgl1-mesa-dev
       - name: (macOS) Install dependencies
         if: matrix.os == 'macOS-latest'
         run: brew install ninja p7zip
       - name: Get Skia from cache
         id: skia-cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: skia
           key: skia-${{ matrix.os }}-cache
-      - name: Download Skia if not in cache
-        if: steps.skia-cache.outputs.cache-hit != 'true'
+      - name: Download Skia if not in cache (linux)
+        if: steps.skia-cache.outputs.cache-hit != 'true' && matrix.os == 'ubuntu-latest'
         run: |
-          curl -o Skia-${{ runner.os }}-Release-X64.zip -L https://github.com/aseprite/skia/releases/download/m102-861e4743af/Skia-${{ runner.os }}-Release-X64.zip
+          curl -o Skia-${{ runner.os }}-Release-X64.zip -L https://github.com/aseprite/skia/releases/download/m102-861e4743af/Skia-${{ runner.os }}-Release-x64-libstdc++.zip
+          unzip Skia-${{ runner.os }}-Release-X64.zip -d skia
+      - name: Download Skia if not in cache
+        if: steps.skia-cache.outputs.cache-hit != 'true' && matrix.os != 'ubuntu-latest'
+        run: |
+          curl -o Skia-${{ runner.os }}-Release-X64.zip -L https://github.com/aseprite/skia/releases/download/m102-861e4743af/Skia-${{ runner.os }}-Release-x64.zip
           unzip Skia-${{ runner.os }}-Release-X64.zip -d skia
       - name: Download Aseprite release
         run: |
@@ -96,10 +103,10 @@ jobs:
       - name: (Windows) Set architecture for the produced binary
         if: matrix.os == 'windows-latest'
         shell: cmd
-        run: call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64
+        run: call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64
       - name: (Windows) Setting Visual Studio build environment variables and paths
         if: matrix.os == 'windows-latest'
-        uses: seanmiddleditch/gha-setup-vsdevenv@v1
+        uses: seanmiddleditch/gha-setup-vsdevenv@v4
       - name: (Windows) Run CMake
         if: matrix.os == 'windows-latest'
         working-directory: aseprite/build
@@ -112,7 +119,7 @@ jobs:
       - name: (macOS) Run CMake
         if: matrix.os == 'macOS-latest'
         working-directory: aseprite/build
-        run: cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -DLAF_BACKEND=skia -DSKIA_DIR=../../skia -DSKIA_LIBRARY_DIR=../../skia/out/Release-x64 -G Ninja ..
+        run: cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 -DCMAKE_OSX_SYSROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk -DLAF_BACKEND=skia -DSKIA_DIR=../../skia -DSKIA_LIBRARY_DIR=../../skia/out/Release-x64 -G Ninja ..
       - name: Run Ninja
         working-directory: aseprite/build
         run: ninja aseprite

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -76,9 +76,7 @@ jobs:
       - name: (Windows) Enable SSL
         if: matrix.os == 'windows-latest'
         shell: powershell
-        run: |
-          echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-          vcpkg install openssl:x64-windows-static-md
+        run: choco install openssl
       - name: (Ubuntu) Install dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt update && sudo apt install -y cmake ninja-build libxcursor-dev libxi-dev libgl1-mesa-dev
@@ -117,7 +115,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         working-directory: aseprite/build
         shell: cmd
-        run: cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_IGNORE_PATH='C:/ProgramData/chocolatey/bin/;C:/Strawberry/c/bin/' -DLAF_BACKEND=skia -DSKIA_DIR=../../skia -DSKIA_LIBRARY_DIR=../../skia/out/Release-x64 -G Ninja ..
+        run: cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_IGNORE_PATH='C:/ProgramData/chocolatey/bin/;C:/Strawberry/c/bin/' -DLAF_BACKEND=skia -DSKIA_DIR=../../skia -DSKIA_LIBRARY_DIR=../../skia/out/Release-x64 -DSKIA_LIBRARY=../../skia/out/Release-x64/skia.lib -G Ninja ..
       - name: (Ubuntu) Run CMake
         if: matrix.os == 'ubuntu-latest'
         working-directory: aseprite/build

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -96,7 +96,7 @@ jobs:
       - name: (Windows) Set architecture for the produced binary
         if: matrix.os == 'windows-latest'
         shell: cmd
-        run: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64
+        run: call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=x64
       - name: (Windows) Setting Visual Studio build environment variables and paths
         if: matrix.os == 'windows-latest'
         uses: seanmiddleditch/gha-setup-vsdevenv@v1

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -73,10 +73,10 @@ jobs:
       - name: (Windows) Install dependencies
         if: matrix.os == 'windows-latest'
         uses: seanmiddleditch/gha-setup-ninja@v3
-      - name: (Windows) Enable SSL
+      - name: (Windows) Remove OpenSLL from PATH
         if: matrix.os == 'windows-latest'
         shell: powershell
-        run: choco install openssl
+        run: Remove-Item -Recurse -Force "C:\Program Files\OpenSSL\"
       - name: (Ubuntu) Install dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt update && sudo apt install -y cmake ninja-build libxcursor-dev libxi-dev libgl1-mesa-dev

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -73,6 +73,12 @@ jobs:
       - name: (Windows) Install dependencies
         if: matrix.os == 'windows-latest'
         uses: seanmiddleditch/gha-setup-ninja@v3
+      - name: (Windows) Enable SSL
+        if: matrix.os == 'windows-latest'
+        shell: powershell
+        run: |
+          echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+          vcpkg install openssl:x64-windows-static-md
       - name: (Ubuntu) Install dependencies
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt update && sudo apt install -y cmake ninja-build libxcursor-dev libxi-dev libgl1-mesa-dev

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 env:
   BUILD_TYPE: Release
@@ -84,7 +85,7 @@ jobs:
       - name: Download Skia if not in cache
         if: steps.skia-cache.outputs.cache-hit != 'true'
         run: |
-          curl -o Skia-${{ runner.os }}-Release-X64.zip -L https://github.com/aseprite/skia/releases/download/m81-b607b32047/Skia-${{ runner.os }}-Release-X64.zip
+          curl -o Skia-${{ runner.os }}-Release-X64.zip -L https://github.com/aseprite/skia/releases/download/m102-861e4743af/Skia-${{ runner.os }}-Release-X64.zip
           unzip Skia-${{ runner.os }}-Release-X64.zip -d skia
       - name: Download Aseprite release
         run: |

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -57,7 +57,7 @@ jobs:
         release_name: Release Aseprite ${{ steps.version_info.outputs.latest_tag }}
         body: |
           ${{ steps.version_info.outputs.version_info }}
-        draft: true
+        draft: false
         prerelease: false
 
   build-aseprite:

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -57,7 +57,7 @@ jobs:
         release_name: Release Aseprite ${{ steps.version_info.outputs.latest_tag }}
         body: |
           ${{ steps.version_info.outputs.version_info }}
-        draft: false
+        draft: true
         prerelease: false
 
   build-aseprite:
@@ -67,7 +67,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
        matrix:
-         os: [windows-latest]
+         os: [windows-latest, ubuntu-latest, macOS-latest]
        fail-fast: false
     steps:
       - name: (Windows) Install dependencies

--- a/.github/workflows/aseprite_build_deploy.yml
+++ b/.github/workflows/aseprite_build_deploy.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   BUILD_TYPE: Release
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
   
 jobs:
   check-version:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-> [!CAUTION]
-> Using the releases is not allowed by the Aseprite project, only me the repo owner are allowed to use the builds!
-> Builds are only accessable as to enable downloading from a scoop repository, not for public use!
-
 # What is it
 Automated workflow for GitHub Actions which builds Aseprite for Windows, Linux, macOS.</br>
 By using GitHub actions there is no need for manual compilation and it does not contain malware.</br>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[!CAUTION]
-Using the releases is not allowed by the Aseprite project, only me the repo owner are allowed to use the builds!
-Builds are only accessable as to enable downloading from a scoop repository, not for public use!
+> [!CAUTION]
+> Using the releases is not allowed by the Aseprite project, only me the repo owner are allowed to use the builds!
+> Builds are only accessable as to enable downloading from a scoop repository, not for public use!
 
 # What is it
 Automated workflow for GitHub Actions which builds Aseprite for Windows, Linux, macOS.</br>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+[!CAUTION]
+Using the releases is not allowed by the Aseprite project, only me the repo owner are allowed to use the builds!
+Builds are only accessable as to enable downloading from a scoop repository, not for public use!
+
 # What is it
 Automated workflow for GitHub Actions which builds Aseprite for Windows, Linux, macOS.</br>
 By using GitHub actions there is no need for manual compilation and it does not contain malware.</br>


### PR DESCRIPTION
Can't make an issue so I thought I'd drop this here, since [upstream](https://github.com/ellisonoswalt/aseprite_builder) is inactive and you seem to be around more often.

For some reason Aseprite wants to link against libcrypto (libcrypto-1_1-x64.dll) at runtime if OpenSSL isn't present at build time. Possible a fix in tooling/toolchains that disrupted behavior. There has been some problems[^1][^2][^3] with OpenSSL in the past and just installing the full OpenSSL from chocolaty seemed to fix the build for me.

It may be there is an alternate fix by setting env variables to point to a preinstalled system OpenSSL, as the windows runner claims[^4] it has OpenSSL 1.1.1w installed, but cmake/ninja don't find it.

Code in PR is included merely as reference as to my fix, no need to merge if you think you can do better.

[^1]: https://github.com/actions/runner-images/issues/371
[^2]: https://github.com/actions/runner-images/issues/8344
[^3]: https://github.com/actions/runner-images/issues/9395 
[^4]: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#tools